### PR TITLE
Added quicksort in Scala

### DIFF
--- a/scala/quicksort.scala
+++ b/scala/quicksort.scala
@@ -1,0 +1,12 @@
+object Quicksort {
+    def quicksort[T](cmp: (T,T) => Boolean, list: List[T]) : List[T] = {
+        list match {
+            case Nil =>
+                Nil
+            case pivot::tl =>
+                val (e1, e2) = tl.partition( (X: T) => cmp(X, pivot) )
+                quicksort(cmp, e1) ::: (pivot::Nil) ::: quicksort(cmp, e2)
+        }
+    }
+}
+


### PR DESCRIPTION
This PR adds the quicksort algorithm, implemented in Scala.
Usage:
```
scalac quicksort.scala
scala (open REPL)
> :load quicksort.scala
> Quicksort.quicksort((X: Int, Y: Int) => X>Y, List(1,-3, 9, 27, 2, 151, 300))
> Quicksort.quicksort((X: Int, Y: Int) => X<Y, List(1,-3, 9, 27, 2, 151, 300))
```