### PR TITLE
Added quicksort in Erlang

### DIFF
--- a/erlang/quicksort.erl
+++ b/erlang/quicksort.erl
@@ -1,0 +1,7 @@
+-module(quicksort).
+-export([quicksort/2]).
+
+quicksort(_, []) ->
+    [];
+quicksort(P, [Pivot | T]) ->
+    quicksort(P, [X || X <- T, P(X, Pivot)]) ++ [Pivot] ++ quicksort(P, [X || X <- T, not P(X, Pivot)]).


### PR DESCRIPTION
This PR adds:
1. the **Erlang folder**;
2. the **quicksort algorithm** (written in Erlang).

Usage:
```
erl (open REPL)
> c(quicksort)
> quicksort:quicksort(fun(X,Y)-> X>Y end, [1,8,9,7,5,0,100,158,-97]).
> quicksort:quicksort(fun(X,Y)-> X<Y end, [1,8,9,7,5,0,100,158,-97]).
```
